### PR TITLE
Tweak fill

### DIFF
--- a/run_plan.py
+++ b/run_plan.py
@@ -253,8 +253,8 @@ class Plan:
     def graph(self, stream):
         """Emit the Plan as a graph."""
         stream.write("digraph {\n")
-        stream.write('  "start" [ shape=circle fillcolor=gray ]\n')
-        stream.write('  "end" [ shape=octagon fillcolor=gray ]\n')
+        stream.write('  "start" [ shape=circle fillcolor=gray style=filled ]\n')
+        stream.write('  "end" [ shape=octagon fillcolor=gray style=filled ]\n')
         is_precond = set()
         for name in sorted(self._actions):
             self._actions[name].node(stream)
@@ -398,7 +398,7 @@ class Prompt(Action):
 
     def node(self, stream):
         """Return the node as per how it should look in a graph."""
-        stream.write(f'  "{self._name}" [ shape=note fillcolor={self._color()} ]\n')
+        stream.write(f'  "{self._name}" [ shape=note fillcolor={self._color()} style=filled ]\n')
 
 
 class Set(Action):
@@ -431,7 +431,7 @@ class Set(Action):
 
     def node(self, stream):
         """Return the node as per how it should look in a graph."""
-        stream.write(f'  "{self._name}" [ shape=polygon fillcolor={self._color()} ]\n')
+        stream.write(f'  "{self._name}" [ shape=polygon fillcolor={self._color()} style=filled ]\n')
 
 
 class Command(Action):
@@ -472,7 +472,7 @@ class Command(Action):
 
     def node(self, stream):
         """Return the node as per how it should look in a graph."""
-        stream.write(f'  "{self._name}" [ shape=component fillcolor={self._color()} ]\n')
+        stream.write(f'  "{self._name}" [ shape=component fillcolor={self._color()} style=filled ]\n')
 
 
 def build_action(data):

--- a/run_plan.py
+++ b/run_plan.py
@@ -502,7 +502,7 @@ def build_action(data):
         action_type = Prompt
 
     if action_type is None:
-        if name in data:
+        if 'name' in data:
             raise UnknownAction('Unknown action %s, keys are %s' % (data['name'], data.keys(),))
         raise UnknownAction('Unknown action, keys are %s' % (data.keys(),))
 

--- a/run_plan_test.py
+++ b/run_plan_test.py
@@ -546,7 +546,7 @@ class TestGraph(unittest.TestCase):
         plan = run_plan.load("testdata/plan_small1.yaml")
         sink = io.StringIO()
         plan.graph(sink)
-        want = '''digraph {\n  "start" [ shape=circle fillcolor=gray ]\n  "end" [ shape=octagon fillcolor=gray ]\n  "test" [ shape=component fillcolor=gray ]\n  "start" -> "test"\n  "test" -> "end"\n}\n'''
+        want = '''digraph {\n  "start" [ shape=circle fillcolor=gray style=filled ]\n  "end" [ shape=octagon fillcolor=gray style=filled ]\n  "test" [ shape=component fillcolor=gray style=filled ]\n  "start" -> "test"\n  "test" -> "end"\n}\n'''
         self.assertEqual(sink.getvalue(), want)
         sink.close()
 
@@ -554,14 +554,14 @@ class TestGraph(unittest.TestCase):
         plan = run_plan.load("testdata/restore_graph.yaml")
         sink = io.StringIO()
         plan.graph(sink)
-        want = '''digraph {\n  "start" [ shape=circle fillcolor=gray ]\n  "end" [ shape=octagon fillcolor=gray ]\n  "prompter" [ shape=note fillcolor=green ]\n  "runner" [ shape=component fillcolor=red ]\n  "setvar" [ shape=polygon fillcolor=gray ]\n  "prompter" -> "runner"\n  "prompter" -> "setvar"\n  "start" -> "prompter"\n  "runner" -> "end"\n  "setvar" -> "end"\n}\n'''
+        want = '''digraph {\n  "start" [ shape=circle fillcolor=gray style=filled ]\n  "end" [ shape=octagon fillcolor=gray style=filled ]\n  "prompter" [ shape=note fillcolor=green style=filled ]\n  "runner" [ shape=component fillcolor=red style=filled ]\n  "setvar" [ shape=polygon fillcolor=gray style=filled ]\n  "prompter" -> "runner"\n  "prompter" -> "setvar"\n  "start" -> "prompter"\n  "runner" -> "end"\n  "setvar" -> "end"\n}\n'''
         self.assertEqual(sink.getvalue(), want)
         sink.close()
 
     def test_graph(self):
         sink = io.StringIO()
         run_plan.graph("testdata/plan_small1.yaml", out=sink)
-        want = '''digraph {\n  "start" [ shape=circle fillcolor=gray ]\n  "end" [ shape=octagon fillcolor=gray ]\n  "test" [ shape=component fillcolor=gray ]\n  "start" -> "test"\n  "test" -> "end"\n}\n'''
+        want = '''digraph {\n  "start" [ shape=circle fillcolor=gray style=filled ]\n  "end" [ shape=octagon fillcolor=gray style=filled ]\n  "test" [ shape=component fillcolor=gray style=filled ]\n  "start" -> "test"\n  "test" -> "end"\n}\n'''
         self.assertEqual(sink.getvalue(), want)
         sink.close()
         


### PR DESCRIPTION
With some experimentation, the graph was not colouring the graph properly for resume files. This PR fixes that.

While running the tests to ensure everything was still working, another bug was spotted. Instead of raising a second PR, this PR actually fixes two problems, as there was a `name` that should have been a `'name'`.